### PR TITLE
Update proxy-agent to v6.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "aws-sdk": "^2.224.1",
     "chalk": "^2.3.1",
-    "proxy-agent": "^5.0.0",
+    "proxy-agent": "^6.0.0",
     "randomstring": "^1.1.5"
   }
 }


### PR DESCRIPTION
Versions of proxy-agent < 6.0 use "vm2" as a dependency which is discontinued due to security issues (see https://github.com/patriksimek/vm2).